### PR TITLE
Add chatbot tool callbacks and example template

### DIFF
--- a/rapidtext-ai-text-block.php
+++ b/rapidtext-ai-text-block.php
@@ -12,6 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 define('RAPIDTEXTAI_PLUGIN_DIR', plugin_dir_path( __FILE__ ));
 require_once RAPIDTEXTAI_PLUGIN_DIR . 'rapidtext-ai-meta-box.php';
 require_once RAPIDTEXTAI_PLUGIN_DIR . 'rapidtextai-openaihandler.php';
+require_once RAPIDTEXTAI_PLUGIN_DIR . 'rapidtextai-chatbot-tools.php';
 
 add_action('admin_notices', 'rapidtextai_admin_notice');
 

--- a/rapidtextai-chatbot-tools.php
+++ b/rapidtextai-chatbot-tools.php
@@ -1,0 +1,95 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+/**
+ * Simple registry for PHP callback tools used by the chatbot.
+ */
+
+global $rapidtextai_tool_callbacks;
+$rapidtextai_tool_callbacks = [];
+
+/**
+ * Register a callback that the chatbot can invoke.
+ *
+ * @param string   $name     Unique tool name.
+ * @param callable $callback Function to execute when the tool is called.
+ */
+function rapidtextai_register_tool_callback( $name, $callback ) {
+    global $rapidtextai_tool_callbacks;
+    $rapidtextai_tool_callbacks[ $name ] = $callback;
+}
+
+/**
+ * Execute a registered tool callback.
+ *
+ * @param string $name Tool name.
+ * @param array  $args Arguments passed from the chatbot.
+ *
+ * @return mixed|\WP_Error
+ */
+function rapidtextai_execute_tool( $name, $args = [] ) {
+    global $rapidtextai_tool_callbacks;
+
+    if ( isset( $rapidtextai_tool_callbacks[ $name ] ) && is_callable( $rapidtextai_tool_callbacks[ $name ] ) ) {
+        return call_user_func( $rapidtextai_tool_callbacks[ $name ], $args );
+    }
+
+    return new WP_Error( 'rapidtextai_tool_not_found', __( 'Tool not registered', 'rapidtextai' ) );
+}
+
+/**
+ * Persist a PHP code snippet so it can be used as a tool later.
+ *
+ * @param string $name     Unique snippet name.
+ * @param string $php_code PHP code for the callback body. It should return a value.
+ */
+function rapidtextai_save_tool_snippet( $name, $php_code ) {
+    $snippets = get_option( 'rapidtextai_tool_snippets', [] );
+    $snippets[ $name ] = $php_code;
+    update_option( 'rapidtextai_tool_snippets', $snippets );
+}
+
+/**
+ * Load saved snippets and register them as callbacks.
+ */
+function rapidtextai_load_tool_snippets() {
+    $snippets = get_option( 'rapidtextai_tool_snippets', [] );
+
+    foreach ( $snippets as $name => $php_code ) {
+        $callback = function( $args ) use ( $php_code ) {
+            return eval( $php_code );
+        };
+        rapidtextai_register_tool_callback( $name, $callback );
+    }
+}
+add_action( 'init', 'rapidtextai_load_tool_snippets' );
+
+/**
+ * Example booking tool callback.
+ *
+ * @param array $args {
+ *     @type string $name Guest name.
+ *     @type string $date Booking date in YYYY-MM-DD format.
+ * }
+ *
+ * @return array
+ */
+function rapidtextai_book_room_tool( $args ) {
+    $name = sanitize_text_field( $args['name'] ?? '' );
+    $date = sanitize_text_field( $args['date'] ?? '' );
+
+    if ( empty( $name ) || empty( $date ) ) {
+        return [
+            'status'  => 'error',
+            'message' => __( 'Missing name or date', 'rapidtextai' ),
+        ];
+    }
+
+    // This is only a demonstration. In a real scenario you would interact with your booking system.
+    return [
+        'status'  => 'success',
+        'message' => sprintf( __( 'Booked %1$s on %2$s', 'rapidtextai' ), $name, $date ),
+    ];
+}
+rapidtextai_register_tool_callback( 'book_room', 'rapidtextai_book_room_tool' );
+

--- a/readme.txt
+++ b/readme.txt
@@ -79,6 +79,25 @@ For detailed terms and privacy, visit the following links:
 3. Enter your prompt in the block to generate AI content instantly.
 4. Customize the output text as needed using the editor.
 
+== Chatbot Tools ==
+
+Expose custom PHP callbacks to the RapidTextAI chatbot using the tool registry.
+
+```php
+rapidtextai_register_tool_callback('book_room', function( $args ) {
+    $name = sanitize_text_field( $args['name'] );
+    $date = sanitize_text_field( $args['date'] );
+
+    // your booking logic here
+    return [ 'status' => 'success', 'message' => "Booked $name on $date" ];
+});
+
+// Save a snippet for later reuse
+rapidtextai_save_tool_snippet('greet_user', 'return "Hello " . sanitize_text_field($args["name"]);');
+```
+
+See `tool-example.json` for an OpenAI tool definition describing the `book_room` callback.
+
 == Screenshots ==
 
 1. **Screenshot 7** - RapidTextAI Article Advance Generate

--- a/tool-example.json
+++ b/tool-example.json
@@ -1,0 +1,22 @@
+{
+  "tools": [
+    {
+      "name": "book_room",
+      "description": "Book a room for a guest",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Guest name"
+          },
+          "date": {
+            "type": "string",
+            "description": "Booking date in YYYY-MM-DD format"
+          }
+        },
+        "required": ["name", "date"]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add registry for chatbot PHP tool callbacks and snippet saving
- wire plugin to include new chatbot tools file
- document JSON tool schema with booking example

## Testing
- `php -l rapidtextai-chatbot-tools.php`
- `php -l rapidtext-ai-text-block.php`


------
https://chatgpt.com/codex/tasks/task_e_68c7c75edb8483319d7aa8e99e4a7f37